### PR TITLE
Fixed UID setting on zsh

### DIFF
--- a/snapcraft-docker
+++ b/snapcraft-docker
@@ -7,7 +7,7 @@ if [ ${ARCH} = "x86_64" ] ; then
     ARCH=amd64
 fi
 
-UID="${USERID:-$(id -u)}"
+[[ ! $(ps -p $$) =~ "zsh" ]] && UID="${USERID:-$(id -u)}"
 
 docker run -u ${UID} -t -i --rm -v $(pwd):/build \
     --privileged=true \


### PR DESCRIPTION
On zsh, `$UID` is already set, and cannot be changed - resulting in a script fail:
```
$ snapcraft-docker
zsh: failed to change user ID: operation not permitted
```

This fix skips the UID setting if zsh is the current shell. It doesn't allow setting a custom UID value, though.